### PR TITLE
Double buffer flicker removal

### DIFF
--- a/game_mgr.cpp
+++ b/game_mgr.cpp
@@ -26,11 +26,6 @@
 #define GFXOPENARG ALLEGRO_WINDOWED
 #endif
 
-/*  write to a double buffer before the screen
-    On x86 / windows a double buffer slow performance
-    On Raspberry Pi, no double buffer results in screen flicker*/
-//#define DOUBLEBUFFER
-
 // initialise static members
 int GameManager::display_height;
 int GameManager::display_width;
@@ -133,7 +128,7 @@ void GameManager::ChangeScreenRes(int width, int height) {
 }
 
 void GameManager::Shutdown() {
-  al_destroy_display(display);
+  al_destroy_display(GameManager::display);
 
   for (int i = 0; i < MAX_NUM_CONTROLLERS; i++)
     delete GameManager::joysticks[i];
@@ -182,12 +177,8 @@ void GameManager::Run(GameSequence *aSeq) {
   al_register_event_source(event_queue, xc_get_event_source());
 
   ALLEGRO_BITMAP *screen_buffer;
-#ifdef DOUBLEBUFFER
-  screen_buffer =
-      al_create_bitmap(GameManager::display_width, GameManager::display_height);
-#else
   screen_buffer = al_get_backbuffer(GameManager::display);
-#endif
+
   al_set_target_bitmap(screen_buffer);
   al_clear_to_color(al_map_rgb(0, 0, 0));
 
@@ -265,11 +256,9 @@ void GameManager::Run(GameSequence *aSeq) {
 
     draw_fps(screen_buffer);
 
-#ifdef DOUBLEBUFFER
-    al_set_target_bitmap(al_get_backbuffer(GameManager::display));
-    al_draw_bitmap(screen_buffer, 0, 0, 0);
-#endif
-    al_flip_display();
+    if (do_tick) {
+      al_flip_display();
+    }
 
     if (doexit) {
       if (seq_next != nullptr && seq_next->ReturnScreen() != aSeq)
@@ -285,5 +274,4 @@ void GameManager::Run(GameSequence *aSeq) {
   }
 
   al_destroy_event_queue(event_queue);
-  al_destroy_bitmap(screen_buffer);
 }

--- a/intro_sequence.cpp
+++ b/intro_sequence.cpp
@@ -45,6 +45,8 @@ IntroSequence::IntroSequence(GameSequence *previous, float zoom,
 IntroSequence::~IntroSequence() {
   if (iLogo)
     al_destroy_bitmap(iLogo);
+  if (iDoublebuffer)
+    al_destroy_bitmap(iDoublebuffer);
 }
 
 GameSequence *IntroSequence::doTick(ALLEGRO_BITMAP *screen_buffer,

--- a/intro_sequence.h
+++ b/intro_sequence.h
@@ -25,8 +25,8 @@ private:
   double iZoom;
   double iZoomMax;
   double iZoomSpeed;
-  ALLEGRO_BITMAP *iLogo;
-  ALLEGRO_BITMAP *iDoublebuffer;
+  ALLEGRO_BITMAP *iLogo = nullptr;
+  ALLEGRO_BITMAP *iDoublebuffer = nullptr;
 
   int width;
   int height;


### PR DESCRIPTION
Remove usage of double buffer and only flip display if a tick has been done

This is to make sure we only flip when the screen has actually updated. This removed the flicker on my laptop