### PR TITLE
Explosion sprite frame crash

### DIFF
--- a/player_view.cpp
+++ b/player_view.cpp
@@ -345,15 +345,14 @@ void draw_explosion(struct player_info *allpi, struct platform_data *plats,
             allpi[i].ship->xpos, allpi[i].ship->ypos);
 
         // if the ship has exploded across the gap, draw it on the other side
-        if (currentlevel->edgedata.wrapx)
-          if ((currentlevel->edgedata.wrapx) &&
-              (allpi[i].ship->xpos + 32 > currentlevel->edgedata.rightx)) {
-            draw_sprite(
-                currentlevel->level_buffer,
-                get_sprite_explosion_frame(allpi[i].ship->explode_count * 40),
-                allpi[i].ship->xpos - al_get_bitmap_width(currentlevel->bitmap),
-                allpi[i].ship->ypos);
-          }
+        if (currentlevel->edgedata.wrapx &&
+            (allpi[i].ship->xpos + 32 > currentlevel->edgedata.rightx)) {
+          draw_sprite(
+              currentlevel->level_buffer,
+              get_sprite_explosion_frame(allpi[i].ship->explode_count * 40),
+              allpi[i].ship->xpos - al_get_bitmap_width(currentlevel->bitmap),
+              allpi[i].ship->ypos);
+        }
         allpi[i].ship->explode_count += dt;
         allpi[i].ship->explode_tick++;
       } else {

--- a/player_view.cpp
+++ b/player_view.cpp
@@ -334,14 +334,17 @@ void put_big_pixel(ALLEGRO_BITMAP *bmp, int x, int y, ALLEGRO_COLOR color) {
 void draw_explosion(struct player_info *allpi, struct platform_data *plats,
                     int nombre_vaisseau, struct level_data *currentlevel,
                     double dt) {
-  int i;
-  int j;
-  for (i = 0; i < nombre_vaisseau; i++) {
+  constexpr double EXPLODE_TIME_SECS = 5;
+  constexpr double EXPLODE_DRAW_TIME_SECS = 1.2;
+
+  for (int i = 0; i < nombre_vaisseau; i++) {
     if (allpi[i].ship->explode) {
-      if (allpi[i].ship->explode_count < (48 * 0.025)) {
+      if (allpi[i].ship->explode_count < EXPLODE_DRAW_TIME_SECS) {
+        auto sprite = get_sprite_explosion_frame(allpi[i].ship->explode_count, EXPLODE_DRAW_TIME_SECS);
+
         draw_sprite(
             currentlevel->level_buffer,
-            get_sprite_explosion_frame(allpi[i].ship->explode_count * 40),
+            sprite,
             allpi[i].ship->xpos, allpi[i].ship->ypos);
 
         // if the ship has exploded across the gap, draw it on the other side
@@ -349,14 +352,14 @@ void draw_explosion(struct player_info *allpi, struct platform_data *plats,
             (allpi[i].ship->xpos + 32 > currentlevel->edgedata.rightx)) {
           draw_sprite(
               currentlevel->level_buffer,
-              get_sprite_explosion_frame(allpi[i].ship->explode_count * 40),
+              sprite,
               allpi[i].ship->xpos - al_get_bitmap_width(currentlevel->bitmap),
               allpi[i].ship->ypos);
         }
         allpi[i].ship->explode_count += dt;
         allpi[i].ship->explode_tick++;
       } else {
-        if (allpi[i].ship->explode_count < 200 * 0.025) {
+        if (allpi[i].ship->explode_count < EXPLODE_TIME_SECS) {
           allpi[i].ship->explode_count += dt;
           allpi[i].ship->explode_tick++;
         } else {

--- a/player_view.cpp
+++ b/player_view.cpp
@@ -337,7 +337,7 @@ void draw_explosion(struct player_info *allpi, struct platform_data *plats,
   int i;
   int j;
   for (i = 0; i < nombre_vaisseau; i++) {
-    if (allpi[i].ship->explode)
+    if (allpi[i].ship->explode) {
       if (allpi[i].ship->explode_count < (48 * 0.025)) {
         draw_sprite(
             currentlevel->level_buffer,
@@ -368,6 +368,7 @@ void draw_explosion(struct player_info *allpi, struct platform_data *plats,
           allpi[i].nblives--;
         }
       }
+    }
   }
 }
 

--- a/vaisseau_gfx.cpp
+++ b/vaisseau_gfx.cpp
@@ -1,6 +1,7 @@
 #include "vaisseau_gfx.h"
 
 #include "allegro_compatibility.h"
+#include <cmath>
 
 bool init_vaisseau_gfx_from_file(struct vaisseau_gfx *vaisseau, const char *normal,
                                  const char *thrust, const char *thrust2, const char *shield) {
@@ -27,8 +28,9 @@ void cleanup_vaisseau_gfx(struct vaisseau_gfx *vaisseau) {
     al_destroy_bitmap(vaisseau->sprite_thrust2);
 }
 
+#define NUM_EXPLOSION_FRAMES 24
 ALLEGRO_BITMAP *sprite_explode;
-ALLEGRO_BITMAP *sprite_explosion_frames[24];
+ALLEGRO_BITMAP *sprite_explosion_frames[NUM_EXPLOSION_FRAMES];
 
 int init_sprite_explosion(const char *bmpname) {
   sprite_explode = al_load_bitmap(bmpname);
@@ -45,13 +47,19 @@ int init_sprite_explosion(const char *bmpname) {
 
 void cleanup_sprite_explosion() {
   int i;
-  for (i = 0; i < 24; i++)
+  for (i = 0; i < NUM_EXPLOSION_FRAMES; i++)
     al_destroy_bitmap(sprite_explosion_frames[i]);
   al_destroy_bitmap(sprite_explode);
 }
 
 ALLEGRO_BITMAP *get_sprite_explosion() { return sprite_explode; }
 
-ALLEGRO_BITMAP *get_sprite_explosion_frame(int i) {
-  return sprite_explosion_frames[i / 2];
+ALLEGRO_BITMAP *get_sprite_explosion_frame(double curr_time, double end_time) {
+  assert(curr_time <= end_time);
+  assert(curr_time >= 0);
+  assert(end_time >= 0);
+
+  size_t index = static_cast<size_t>(std::round((NUM_EXPLOSION_FRAMES-1) * curr_time/end_time));
+
+  return sprite_explosion_frames[index];
 }

--- a/vaisseau_gfx.h
+++ b/vaisseau_gfx.h
@@ -16,5 +16,5 @@ void cleanup_vaisseau_gfx(struct vaisseau_gfx *vaisseau);
 int init_sprite_explosion(const char *bmpname);
 ALLEGRO_BITMAP *get_sprite_explosion();
 void cleanup_sprite_explosion();
-ALLEGRO_BITMAP *get_sprite_explosion_frame(int i);
+ALLEGRO_BITMAP *get_sprite_explosion_frame(double curr_time, double end_time);
 #endif


### PR DESCRIPTION
When running with very slow fps the calculated frame sprite number could become too high leading to a crash when reading outside the sprite array. This fixes the issue and makes the code a bit clearer.